### PR TITLE
Fix typo in update.json  (juicy-tile-list)

### DIFF
--- a/files/juicy-tile-list/update.json
+++ b/files/juicy-tile-list/update.json
@@ -4,7 +4,7 @@
   "repo": "Juicy/juicy-tile-list",
   "files": {
     "include": [
-    	"dist/juicy-tile-list.html"
+    	"dist/juicy-tile-list.html",
     	"dist/package.js",
     	"dist/package.js.map",
     	"dist/packer.js",


### PR DESCRIPTION
after jsdelivr/jsdelivr#1250
