### PR TITLE
Waffles release 1.0.0. Minified with proper info.ini and version directo...

### DIFF
--- a/files/waffles/info.ini
+++ b/files/waffles/info.ini
@@ -1,0 +1,5 @@
+author = "Jesse Harlin"
+github = "https://github.com/JesseHarlin/waffles"
+homepage = "http://jesseharlin.github.io/Waffles"
+description = "A responsive grid framework that supports automatic sizing and mixed fixed/fluid layouts."
+mainfile = "waffles.min.css"

--- a/files/waffles/update.json
+++ b/files/waffles/update.json
@@ -1,0 +1,9 @@
+{
+	"packageManager": "github",
+	"name": "waffles",
+	"repo": "jesseharlin/waffles",
+	"files": {
+		"basePath": "dist",
+		"include": ["waffles.min.css"]
+	}
+}


### PR DESCRIPTION
Waffles Grid Release 1.0.0 for inclusion into the jsDelivr CDN

https://github.com/JesseHarlin/waffles if you would like to learn more
- Single minified waffles.min.css added. (first time addition is minified only, correct?)
- info.ini set up with author's information.
- version 1.0.0 set up with no READMEs/other artifacts as per the directions.

Let me know if I need to change/add anything else!

Thanks,
- Joe
