### PR TITLE
Removed steno.crushed.js

### DIFF
--- a/files/steno.js/update.json
+++ b/files/steno.js/update.json
@@ -3,6 +3,6 @@
   "name": "steno.js",
   "repo": "kenshinthebattosai/steno.js",
   "files": {
-    "include": ["steno.crushed.js", "steno.min.js"]
+    "include": ["steno.min.js"]
   }
 }


### PR DESCRIPTION
Min File itself is <4KB.
I do not see any reason to pack/crush it.
