### PR TITLE
+ open-iconic/update.json, needs opinion

### DIFF
--- a/files/open-iconic/update.json
+++ b/files/open-iconic/update.json
@@ -1,0 +1,8 @@
+{
+  "packageManager": "github",
+  "name": "open-iconic",
+  "repo": "iconic/open-iconic",
+  "files": {
+    "include": ["./font/css/*.min.css","./font/fonts/*.*","./sprite/*.min.svg"]
+  }
+}


### PR DESCRIPTION
So seems the [WebP](https://github.com/jsdelivr/jsdelivr/tree/master/files/open-iconic/1.1.0/webp) images were uploaded, but not the far more browser-supported [PNG](https://github.com/iconic/open-iconic/tree/master/png)s.  1300 images is quite a few but 1300_2_new version every 3-4 months is alot.

Maybe drop both until people ask for them?  Really the thrust of Iconic is individual SVG images.  The fonts & raster images are provided as a backup.  No one complained that the PNGs were missing, even though they're required by IE8.  (& IMHO SVG should be THE format for icons).

@somerandomdude this file is for automated uploads to the CDN.
