### PR TITLE
Add auto-updater for bootswatch.

### DIFF
--- a/files/bootswatch/update.json
+++ b/files/bootswatch/update.json
@@ -1,0 +1,4 @@
+{
+    "packageManager": "bower",
+    "name": "bootswatch"
+}


### PR DESCRIPTION
jsDelivr is missing the latest releases (3.3.1 onwards)