### PR TITLE
update urls to Fast-JSON-Patch

### DIFF
--- a/files/fast-json-patch/info.ini
+++ b/files/fast-json-patch/info.ini
@@ -1,5 +1,5 @@
 author = "Joachim Wester"
-github = "https://github.com/Starcounter-Jack/JSON-Patch"
-homepage = "https://github.com/Starcounter-Jack/JSON-Patch"
+github = "https://github.com/Starcounter-Jack/Fast-JSON-Patch"
+homepage = "https://github.com/Starcounter-Jack/Fast-JSON-Patch"
 mainfile = "json-patch.min.js"
-description = "Lean and mean Javascript implementation of the JSON-Patch standard. Update JSON documents using delta patches."
+description = "Fast implementation of JSON-Patch (RFC-6902) with duplex (observe changes) capabilities"

--- a/files/fast-json-patch/update.json
+++ b/files/fast-json-patch/update.json
@@ -1,9 +1,9 @@
 {
   "packageManager": "github",
   "name": "fast-json-patch",
-  "repo": "Starcounter-Jack/JSON-Patch",
+  "repo": "Starcounter-Jack/Fast-JSON-Patch",
   "files": {
     "basePath": "dist/",
-    "include": ["json-patch.min.js", "json-patch.min.js.map", "json-patch-duplex.min.js", "json-patch-duplex.min.js.map"]
+    "include": ["json-patch.min.js", "json-patch-duplex.min.js"]
   }
 }


### PR DESCRIPTION
Fast-JSON-Patch was not autoupdated recently to the current version 0.5.0

Perhaps this is because info.ini and update.json are using outdated URLs. This pull request changes URLs to the current ones.
