### PR TITLE
[author] update angular.textAngular to v1.3.0 format

### DIFF
--- a/files/angular.textangular/update.json
+++ b/files/angular.textangular/update.json
@@ -3,6 +3,9 @@
   "name": "textAngular",
   "repo": "fraywing/textAngular",
   "files": {
-    "include": ["src/textAngular-sanitize.js", "src/textAngular.js", "dist/*.js"]
+    "include": [
+      "src/textAngular.css",
+      "dist/*"
+    ]
   }
 }


### PR DESCRIPTION
Change the include paths to include all the new paths in the v1.3.0 release.
Pre-releases aren't included so this should have no effect until I release the v1.3.0 tag.