### PR TITLE
Update repository on update.json

### DIFF
--- a/files/clappr.level-selector/update.json
+++ b/files/clappr.level-selector/update.json
@@ -1,7 +1,7 @@
 {
   "packageManager": "github",
   "name": "clappr-level-selector-plugin",
-  "repo": "lucasmundim/clappr-level-selector-plugin",
+  "repo": "clappr/clappr-level-selector-plugin",
   "files": {
     "basePath": "dist/",
     "include": ["level-selector.min.js"]


### PR DESCRIPTION
We've moved all clappr plugins to the clappr github organization.