### PR TITLE
Update clappr repositories

### DIFF
--- a/files/clappr.playback-name/info.ini
+++ b/files/clappr.playback-name/info.ini
@@ -1,5 +1,5 @@
 author = "Gustavo Barbosa"
-github = "https://github.com/barbosa/clappr-playback-name-plugin"
-homepage = "https://github.com/barbosa/clappr-playback-name-plugin"
+github = "https://github.com/clappr/clappr-playback-name-plugin"
+homepage = "https://github.com/clappr/clappr-playback-name-plugin"
 description = "A simple plugin for Clappr that adds a label with the playback's name"
 mainfile = "playbackname.min.js"

--- a/files/clappr.playback-name/update.json
+++ b/files/clappr.playback-name/update.json
@@ -1,7 +1,7 @@
 {
   "packageManager": "github",
   "name": "clappr-playback-name-plugin",
-  "repo": "barbosa/clappr-playback-name-plugin",
+  "repo": "clappr/clappr-playback-name-plugin",
   "files": {
     "basePath": "dist/",
     "include": ["playbackname.min.js"]

--- a/files/clappr.rtmp/info.ini
+++ b/files/clappr.rtmp/info.ini
@@ -1,5 +1,5 @@
 author = "Flavio Ribeiro"
-github = "https://github.com/flavioribeiro/clappr-rtmp-plugin"
+github = "https://github.com/clappr/clappr-rtmp-plugin"
 homepage = "http://clappr.io"
 description = "RTMP Support for Clappr Player"
 mainfile = "rtmp.min.js"

--- a/files/clappr.rtmp/update.json
+++ b/files/clappr.rtmp/update.json
@@ -1,7 +1,7 @@
 {
   "packageManager": "github",
   "name": "clappr-rtmp-plugin",
-  "repo": "flavioribeiro/clappr-rtmp-plugin",
+  "repo": "clappr/clappr-rtmp-plugin",
   "files": {
     "basePath": "dist/",
     "include": ["rtmp.min.js", "./assets/**/*"]

--- a/files/clappr/info.ini
+++ b/files/clappr/info.ini
@@ -1,5 +1,5 @@
 author = "Globo.com"
-github = "https://github.com/globocom/clappr"
+github = "https://github.com/clappr/clappr"
 homepage = "http://clappr.io"
 description = "an extensible media player for the web"
 mainfile = "clappr.min.js"

--- a/files/clappr/update.json
+++ b/files/clappr/update.json
@@ -1,7 +1,7 @@
 {
   "packageManager": "github",
   "name": "clappr",
-  "repo": "globocom/clappr",
+  "repo": "clappr/clappr",
   "files": {
     "basePath": "dist/",
     "include": ["clappr.js", "clappr.min.js", "./assets/**/*"]


### PR DESCRIPTION
We've moved all clappr repositories to the clappr github organization.