### PR TITLE
Add here-miss - dnt setting detection.

### DIFF
--- a/files/here-miss/info.ini
+++ b/files/here-miss/info.ini
@@ -1,0 +1,5 @@
+author = "eustasy"
+github = "https://github.com/eustasy/here-miss"
+homepage = "http://labs.eustasy.org/here-miss"
+description = "Do Not Track in a handy set of variables, disabled for IE 10+ users by default (configurable)."
+mainfile = "here-miss.min.js"

--- a/files/here-miss/update.json
+++ b/files/here-miss/update.json
@@ -1,0 +1,8 @@
+{
+	"packageManager": "github",
+	"name": "here-miss",
+	"repo": "eustasy/here-miss",
+	"files": {
+		"include": ["here-miss.min.js"]
+	}
+}


### PR DESCRIPTION
Running libgrabber over this should result in version 1.1 being pulled in.