### PR TITLE
+ T3 (t3js)

### DIFF
--- a/files/t3/info.ini
+++ b/files/t3/info.ini
@@ -1,0 +1,5 @@
+author = "Box, Inc."
+github = "https://github.com/box/t3js"
+homepage = "http://t3js.org/"
+description = "client-side minimal component-based JavaScript framework that provides core structure"
+mainfile = "t3.min.js"

--- a/files/t3/update.json
+++ b/files/t3/update.json
@@ -1,0 +1,9 @@
+{
+  "packageManager": "github",
+  "name": "t3",
+  "repo": "box/t3js",
+  "files": {
+    "basePath": "dist/",
+    "include": ["t3.min.js"]
+  }
+}


### PR DESCRIPTION
I'm OK with hosting only the minified file with a [wrong URL for the `.map` file](https://github.com/box/t3js/issues/31), making including the `.map` file itself pointless.  Not sure if you or they are...

(Still don't think map files belong in production ;) )