### PR TITLE
Adding Library jquery.actual v1.0.16

### DIFF
--- a/files/jquery.actual/info.ini
+++ b/files/jquery.actual/info.ini
@@ -1,0 +1,5 @@
+author = "DreamersLab"
+github = "https://github.com/dreamerslab/jquery.actual"
+homepage = "https://github.com/dreamerslab/jquery.actual"
+description = "Get the actual width/height of invisible DOM elements with jQuery"
+mainfile = "jquery.actual.min.js"

--- a/files/jquery.actual/update.json
+++ b/files/jquery.actual/update.json
@@ -1,0 +1,8 @@
+{
+  "packageManager": "github",
+  "name": "jquery.actual",
+  "repo": "dreamerslab/jquery.actual",
+  "files": {
+    "include": ["jquery.actual.min.js"]
+  }
+}


### PR DESCRIPTION
Repo: https://github.com/dreamerslab/jquery.actual
Description: Get the actual width/height of invisible DOM elements with jQuery.