### PR TITLE
ng file upload

### DIFF
--- a/files/ng-file-upload/info.ini
+++ b/files/ng-file-upload/info.ini
@@ -1,0 +1,5 @@
+author = "Danial Farid"
+github = "https://github.com/danialfarid/ng-file-upload-bower"
+homepage = "https://github.com/danialfarid/ng-file-upload"
+description = "An AngularJS directive for file upload using HTML5 with FileAPI polyfill for unsupported browsers"
+mainfile = "ng-file-upload.min.js"

--- a/files/ng-file-upload/update.json
+++ b/files/ng-file-upload/update.json
@@ -1,0 +1,8 @@
+{
+  "packageManager": "bower",
+  "name": "ng-file-upload",
+  "repo": "danialfarid/ng-file-upload-bower",
+  "files": {
+    "include": ["*.js", "*.ico", "*.swf"]
+  }
+}


### PR DESCRIPTION
ng file upload is already on jsdelivr but it's pointing to the wrong place and doesn't have update.json (so it's outdated) and isn't named consistently with the project.  There is a separate repo maintained for bower releases that should be used instead.

https://github.com/jsdelivr/jsdelivr/tree/master/files/angular.file-upload