### PR TITLE
SimpleMDE (renamed from Markdownify)

### DIFF
--- a/files/markdownify/info.ini
+++ b/files/markdownify/info.ini
@@ -1,5 +1,0 @@
-author = "Next Step Webs, Inc."
-github = "https://github.com/NextStepWebs/markdownify-markdown-editor"
-homepage = "http://nextstepwebs.github.io/markdownify-markdown-editor"
-description = "Markdownify is a simple, embeddable, and beautiful markdown editor"
-mainfile = "markdownify.min.js"

--- a/files/markdownify/update.json
+++ b/files/markdownify/update.json
@@ -1,8 +1,0 @@
-{
-  "packageManager": "github",
-  "name": "markdownify-markdown-editor",
-  "repo": "NextStepWebs/markdownify-markdown-editor",
-  "files": {
-    "include": ["markdownify.min.js", "markdownify.min.css"]
-  }
-}

--- a/files/simplemde/info.ini
+++ b/files/simplemde/info.ini
@@ -1,0 +1,5 @@
+author = "Next Step Webs, Inc."
+github = "https://github.com/NextStepWebs/simplemde-markdown-editor"
+homepage = "http://nextstepwebs.github.io/simplemde-markdown-editor"
+description = "SimpleMDE is a simple, embeddable, and beautiful markdown editor"
+mainfile = "simplemde.min.js"

--- a/files/simplemde/update.json
+++ b/files/simplemde/update.json
@@ -1,0 +1,8 @@
+{
+  "packageManager": "github",
+  "name": "simplemde-markdown-editor",
+  "repo": "NextStepWebs/simplemde-markdown-editor",
+  "files": {
+    "include": ["simplemde.min.js", "simplemde.min.css"]
+  }
+}


### PR DESCRIPTION
A name change was needed, the Markdownify package can be removed and replaced with this one, SimpleMDE. Sorry about that.