### PR TITLE
Add js-cookie (former jquery.cookie)

### DIFF
--- a/files/js-cookie/info.ini
+++ b/files/js-cookie/info.ini
@@ -1,0 +1,4 @@
+github = "https://github.com/js-cookie/js-cookie"
+homepage = "https://github.com/js-cookie/js-cookie"
+description = "A simple, lightweight JavaScript API for handling cookies"
+mainfile = "js.cookie.min.js"

--- a/files/js-cookie/info.ini
+++ b/files/js-cookie/info.ini
@@ -1,3 +1,4 @@
+author = "js-cookie"
 github = "https://github.com/js-cookie/js-cookie"
 homepage = "https://github.com/js-cookie/js-cookie"
 description = "A simple, lightweight JavaScript API for handling cookies"

--- a/files/js-cookie/js-cookie
+++ b/files/js-cookie/js-cookie
@@ -1,0 +1,4 @@
+github = "https://github.com/js-cookie/js-cookie"
+homepage = "https://github.com/js-cookie/js-cookie"
+description = "A simple, lightweight JavaScript API for handling cookies"
+mainfile = "js.cookie.min.js"

--- a/files/js-cookie/js-cookie
+++ b/files/js-cookie/js-cookie
@@ -1,4 +1,0 @@
-github = "https://github.com/js-cookie/js-cookie"
-homepage = "https://github.com/js-cookie/js-cookie"
-description = "A simple, lightweight JavaScript API for handling cookies"
-mainfile = "js.cookie.min.js"

--- a/files/js-cookie/update.json
+++ b/files/js-cookie/update.json
@@ -1,0 +1,8 @@
+{
+  "packageManager": "github",
+  "name": "js-cookie",
+  "repo": "js-cookie/js-cookie",
+  "files": {
+    "include": ["src/js.cookie.js"]
+  }
+}


### PR DESCRIPTION
jQuery dependency was made optional in the version `1.5.0`. `js-cookie` repository contains [all `jquery-cookie` releases/tags](https://github.com/js-cookie/js-cookie/releases) since v1.