### PR TITLE
Update the repo and name of Riot.js

### DIFF
--- a/files/riot/info.ini
+++ b/files/riot/info.ini
@@ -1,5 +1,5 @@
 author = "Muut, Inc."
-github = "https://github.com/muut/riotjs"
+github = "https://github.com/riot/riot"
 homepage = "https://muut.com/riotjs/"
 description = "A React- like, 2.5K user interface library"
 mainfile = "riot.min.js"

--- a/files/riot/update.json
+++ b/files/riot/update.json
@@ -1,7 +1,7 @@
 {
   "packageManager": "github",
-  "name": "riotjs",
-  "repo": "muut/riotjs",
+  "name": "riot",
+  "repo": "riot/riot",
   "files": {
     "include": ["riot.js", "riot.min.js", "compiler.js", "compiler.min.js"]
   }


### PR DESCRIPTION
We've moved to [the new organization](https://github.com/riot) on GitHub resently :)
So some update on `info.ini` and `update.json` are needed. Thanks!