### PR TITLE
Exclude demo files not necessary to the CDN

### DIFF
--- a/files/cookie-bar/update.json
+++ b/files/cookie-bar/update.json
@@ -8,7 +8,8 @@
     	"LICENSE",
     	"README.md",
     	"logo_big.png",
-    	"logo_icon.png"
+    	"logo_icon.png",
+    	"demo/index.html"
     ]
   }
 }


### PR DESCRIPTION
New version of cookieBAR has a demo file which should not added to the CDN, I've added it to the excludes