### PR TITLE
change packageManager of leaflet.esri.gp

### DIFF
--- a/files/leaflet.esri.gp/update.json
+++ b/files/leaflet.esri.gp/update.json
@@ -1,9 +1,10 @@
 {
-  "packageManager": "npm",
+  "packageManager": "github",
   "name": "leaflet.esri.gp",
   "repo": "jgravois/esri-leaflet-gp",
   "files": {
     "basepath": ["dist/"],
-    "include": ["esri-leaflet-gp.js", "esri-leaflet-gp.js.map"]
+    "include": ["esri-leaflet-gp.js", "esri-leaflet-gp.js.map"],
+    "exclude": ["README.md"]
   }
 }


### PR DESCRIPTION
i'm not sure why, but the bot wasn't triggered yesterday when i tagged version [1.0.1](https://www.npmjs.com/package/esri-leaflet-gp) of my plugin on github and npm, so i thought i'd try updating the packageManager...

i'm assuming i'll need to tag another release after this PR is merged.  let me know if i'm missing anything else.