### PR TITLE
update leaflet.esri.heatmap-feature-layer include files

### DIFF
--- a/files/leaflet.esri.heatmap-feature-layer/update.json
+++ b/files/leaflet.esri.heatmap-feature-layer/update.json
@@ -4,6 +4,6 @@
   "repo": "esri/esri-leaflet-heatmap-feature-layer",
   "files": {
     "basePath": "dist/",
-    "exclude": ["README.md"]
+    "include": ["esri-leaflet-heatmap-feature-layer.js", "esri-leaflet-heatmap-feature-layer.js.map"]
   }
 }


### PR DESCRIPTION
resolves #6298

i've made a change to nesure this plugin only distributes minified built source files.  this PR is an update to the metadata for the project in jsdelivr.

~~esri-leaflet-heatmap-feature-layer-src.js~~ >> `esri-leaflet-heatmap-feature-layer.js`

* the `dist` folder no longer includes a README that needs to be ignored (see [here](see [here](https://github.com/Esri/esri-leaflet-heatmap-feature-layer/tree/1712f2e27ad284e79f2e128974e6d7315a6b125f/dist)).

let me know if i'm missing anything else.
thanks!