### PR TITLE
Updating the path to the release folder for library jquery.tagsinput

### DIFF
--- a/files/jquery.tagsinput/update.json
+++ b/files/jquery.tagsinput/update.json
@@ -3,6 +3,6 @@
 	"name": "jquery.tagsinput",
 	"repo": "xoxco/jQuery-Tags-Input",
 	"files": {
-		"include": ["jquery.tagsinput.css", "jquery.tagsinput.min.js"]
+		"basePath": "dist/"
 	}
 }


### PR DESCRIPTION
Repo: https://github.com/xoxco/jQuery-Tags-Input
URL: http://xoxco.com/projects/code/tagsinput/