### PR TITLE
[bootswatch] Remove explicit include and remove fonts from exclude

### DIFF
--- a/files/bootswatch/update.json
+++ b/files/bootswatch/update.json
@@ -3,7 +3,6 @@
   "name": "bootswatch",
   "repo": "thomaspark/bootswatch",
   "files": {
-    "include": ["./*/bootstrap.css", "./*/bootstrap.min.css"],
-    "exclude": ["*(2|api|assets|bower_components|custom|default|fonts|global|help|tests|.gitignore|.travis.yml|CNAME|Gemfile|Gruntfile.js|LICENSE|README.md|_config.yml|bower.json|composer.json|favicon.ico|index.html|package.json)"]
+    "exclude": ["*(2|api|assets|bower_components|custom|default|global|help|tests|.gitignore|.travis.yml|CNAME|Gemfile|Gruntfile.js|LICENSE|README.md|_config.yml|bower.json|composer.json|favicon.ico|index.html|package.json)"]
   }
 }


### PR DESCRIPTION
Follow-up to #6395. Since everything is getting excluded (that needs to be), it should be fine leave the includes at `**/*` actually.

This also fixed the fonts folder from getting removed.