### PR TITLE
[bootswatch] Fix directory/file excludes

### DIFF
--- a/files/bootswatch/update.json
+++ b/files/bootswatch/update.json
@@ -3,6 +3,9 @@
   "name": "bootswatch",
   "repo": "thomaspark/bootswatch",
   "files": {
-    "exclude": ["*(2|api|assets|bower_components|custom|default|global|help|tests|.gitignore|.travis.yml|CNAME|Gemfile|Gruntfile.js|LICENSE|README.md|_config.yml|bower.json|composer.json|favicon.ico|index.html|package.json)"]
+    "exclude": [
+      "2/**", "api/**", "assets/**", "bower_components/**", "custom/**", "default/**", "global/**", "help/**", "tests/**",
+      "*(.gitignore|.travis.yml|CNAME|Gemfile|Gruntfile.js|LICENSE|README.md|_config.yml|bower.json|composer.json|favicon.ico|index.html|package.json)"
+    ]
   }
 }


### PR DESCRIPTION
Ok, this should do it.

1st line: exclude directories. They must be globstar and globstar doesn't work with `*(a|b)`
2nd line: exclude additional files

x-ref: #2515, #6395, #6396, #6399, #6400