### PR TITLE
Update clappr included file paths

### DIFF
--- a/files/clappr/update.json
+++ b/files/clappr/update.json
@@ -3,7 +3,6 @@
   "name": "clappr",
   "repo": "clappr/clappr",
   "files": {
-    "basePath": "dist/",
-    "include": ["clappr.js", "clappr.min.js", "./assets/**/*"]
+    "basePath": "dist/"
   }
 }


### PR DESCRIPTION
Since we updated Clappr to use webpack for building, the assets are now generated directly in the `dist/` folder.