### PR TITLE
Add GraphiQL

### DIFF
--- a/files/graphiql/info.ini
+++ b/files/graphiql/info.ini
@@ -1,0 +1,4 @@
+author = "Lee Byron"
+github = "https://github.com/graphql/graphiql"
+description = "An in-browser IDE for exploring GraphQL"
+mainfile = "graphiql.min.js"

--- a/files/graphiql/update.json
+++ b/files/graphiql/update.json
@@ -1,0 +1,8 @@
+{
+  "packageManager": "npm",
+  "name": "graphiql",
+  "repo": "graphql/graphiql",
+  "files": {
+    "include": [ "graphiql.js", "graphiql.min.js", "graphiql.css" ]
+  }
+}


### PR DESCRIPTION
GraphiQL is an in-browser IDE for GraphQL servers

This adds the pre-bundled files to jsdeliver from npm