### PR TITLE
GraphiQL publish non-minified as a secondary source

### DIFF
--- a/files/graphiql/update.json
+++ b/files/graphiql/update.json
@@ -3,6 +3,6 @@
   "name": "graphiql",
   "repo": "graphql/graphiql",
   "files": {
-    "include": [ "graphiql.min.js", "graphiql.css" ]
+    "include": [ "graphiql.min.js", "graphiql.js", "graphiql.css" ]
   }
 }


### PR DESCRIPTION
Include the non-minified version as a non-default file for easy debugging (swap .min.js to .js)