### PR TITLE
Add cborjs-typedarray-decoder

### DIFF
--- a/files/cborjs-typedarray-decoder/info.ini
+++ b/files/cborjs-typedarray-decoder/info.ini
@@ -1,0 +1,5 @@
+author = "Maik Riechert"
+homepage = "https://github.com/Reading-eScience-Centre/cborjs-typedarray-decoder"
+github = "https://github.com/Reading-eScience-Centre/cborjs-typedarray-decoder"
+description = A cbor-js decoder for CBOR typed arrays"
+mainfile = "cborjs-typedarray-decoder.min.js"

--- a/files/cborjs-typedarray-decoder/info.ini
+++ b/files/cborjs-typedarray-decoder/info.ini
@@ -1,5 +1,5 @@
 author = "Maik Riechert"
 homepage = "https://github.com/Reading-eScience-Centre/cborjs-typedarray-decoder"
 github = "https://github.com/Reading-eScience-Centre/cborjs-typedarray-decoder"
-description = A cbor-js decoder for CBOR typed arrays"
+description = "A cbor-js decoder for CBOR typed arrays"
 mainfile = "cborjs-typedarray-decoder.min.js"

--- a/files/cborjs-typedarray-decoder/update.json
+++ b/files/cborjs-typedarray-decoder/update.json
@@ -1,0 +1,10 @@
+{
+  "packageManager": "npm",
+  "name": "cborjs-typedarray-decoder",
+  "repo": "Reading-eScience-Centre/cborjs-typedarray-decoder",
+  "files": {
+    "include": ["cborjs-typedarray-decoder.min.js", 
+                "cborjs-typedarray-decoder.src.js", 
+                "cborjs-typedarray-decoder.min.js.map"]
+  }
+}


### PR DESCRIPTION
I would really like to include the .src.js and .min.js.map files. In my other package covjson-reader I was ok with skipping them as the .src.js file was already transpiled (from ES6) and it wasn't so useful in general. But here there's no transpilation so I find it very useful to include those files. Since this is a very small library I think it doesn't hurt. (both .src.js and .min.js.map are just 4k)