### PR TITLE
Change React auto-updating to use git

### DIFF
--- a/files/react/update.json
+++ b/files/react/update.json
@@ -1,8 +1,10 @@
 {
-  "packageManager": "npm",
+  "packageManager": "github",
   "name": "react",
-  "repo": "facebook/react",
+  "repo": "reactjs/react-bower",
   "files": {
-    "basePath": "dist/"
+    "include": [
+      "*.js"
+    ]
   }
 }


### PR DESCRIPTION
In facebook/react#4901 we're going to be moving `react-dom.js` outside of the `react` npm package. For now we'd like to keep that file still in the same project here on the CDN (and we're still distributing it with the `react` bower package). In order to do that we need to point the autoupdater at the repo we use for bower instead of npm.

I think the only difference here is that we store RCs here. We always published those to npm as well but because we never used the `latest` tag, they never ended up here.