### PR TITLE
update Vue.js repo

### DIFF
--- a/files/vue/info.ini
+++ b/files/vue/info.ini
@@ -1,5 +1,5 @@
 author = "Evan You"
-github = "https://github.com/yyx990803/vue"
+github = "https://github.com/vuejs/vue"
 homepage = "http://vuejs.org/"
 description = "Intuitive, fast & composable MVVM for building interactive interfaces."
 mainfile = "vue.min.js"

--- a/files/vue/update.json
+++ b/files/vue/update.json
@@ -1,7 +1,7 @@
 {
   "packageManager": "github",
   "name": "vue",
-  "repo": "yyx990803/vue",
+  "repo": "vuejs/vue",
   "files": {
 	"basePath": "dist/",
     "include": ["*.js"]


### PR DESCRIPTION
The Vue.js repo just moved from `yyx990803/vue` to `vuejs/vue`. Is there anything else to make sure the auto update system picks up the change?