### PR TITLE
Update riot available files

### DIFF
--- a/files/riot/update.json
+++ b/files/riot/update.json
@@ -3,6 +3,6 @@
   "name": "riot",
   "repo": "riot/riot",
   "files": {
-    "include": ["riot.js", "riot.min.js", "compiler.js", "compiler.min.js"]
+    "include": ["riot.js", "riot.min.js", "riot+compiler.js", "riot+compiler.min.js"]
   }
 }


### PR DESCRIPTION
The main riot repo does not contain the `compiler.js` and `compiler.min.js` files anymore. We provide `riot+compiler.js` and `riot+compiler.min.js` instead