### PR TITLE
Replaced package manager for jquery

### DIFF
--- a/files/jquery/update.json
+++ b/files/jquery/update.json
@@ -1,5 +1,5 @@
 {
-  "packageManager": "github",
+  "packageManager": "npm",
   "name": "jquery",
   "repo": "jquery/jquery",
   "files": {


### PR DESCRIPTION
Now there are no dist files in the repository on github. So I believe that libgrabber bot will be able to grab a latest version from npm.