### PR TITLE
update(update.json)

### DIFF
--- a/files/scrollreveal.js/update.json
+++ b/files/scrollreveal.js/update.json
@@ -3,6 +3,8 @@
   "name": "scrollreveal",
   "repo": "jlmakes/scrollreveal.js",
   "files": {
-	"basePath": "dist/"
+	"basePath": "dist/",
+	"include": ["scrollreveal.min.js"],
+	"exclude": ["scrollreveal.js"]
   }
 }


### PR DESCRIPTION
Attempting to fix jsdelivr’s mad problems with my automatic PR merges… I don’t see a reason to include the non-minified version, since it seems to just be causing problems.