### PR TITLE
Include image for leaflet-search

### DIFF
--- a/files/leaflet.search/update.json
+++ b/files/leaflet.search/update.json
@@ -3,7 +3,6 @@
   "name": "leaflet-search",
   "repo": "stefanocudini/leaflet-search",
   "files": {
-    "basePath": "dist/",
-    "include": ["*.min.js", "*.min.css"]
+    "include": ["dist/*.min.js", "dist/*.min.css", "images/*"]
   }
 }

--- a/files/leaflet.search/update.json
+++ b/files/leaflet.search/update.json
@@ -3,6 +3,6 @@
   "name": "leaflet-search",
   "repo": "stefanocudini/leaflet-search",
   "files": {
-    "include": ["dist/*.min.js", "dist/*.min.css", "images/*"]
+    "include": ["dist/*.min.js", "dist/*.min.css", "./images/*"]
   }
 }


### PR DESCRIPTION
The old file I build seems to do not include ```images/```; so I have ```404 Not Found``` for ```https://cdn.jsdelivr.net/leaflet.search/images/search-icon.png``` which is automatically called by the .js

Thanks