### PR TITLE
FullCalendar: Update the GitHub URL

### DIFF
--- a/files/fullcalendar/info.ini
+++ b/files/fullcalendar/info.ini
@@ -1,5 +1,5 @@
 author = "Adam Shaw"
-github = "https://github.com/arshaw/fullcalendar"
-homepage = "http://arshaw.com/fullcalendar/"
+github = "https://github.com/fullcalendar/fullcalendar"
+homepage = "http://fullcalendar.io"
 description = "FullCalendar is a jQuery plugin that provides a full-sized, drag & drop calendar. It uses AJAX to fetch events on-the-fly for each month and is easily configured to use your own feed format (an extension is provided for Google Calendar)."
 mainfile = "fullcalendar.min.js"


### PR DESCRIPTION
Not my repo, but I noticed the GitHub URL has changed, so jsDelivr has stopped updating the files.