### PR TITLE
Update refluxjs repo to reflux org

### DIFF
--- a/files/refluxjs/info.ini
+++ b/files/refluxjs/info.ini
@@ -1,5 +1,5 @@
 author = "Mikael Brassman"
-github = "https://github.com/spoike/refluxjs"
-homepage = "https://github.com/spoike/refluxjs"
+github = "https://github.com/reflux/refluxjs"
+homepage = "https://github.com/reflux/refluxjs"
 description = "A simple library for uni-directional dataflow application architecture inspired by ReactJS Flux"
 mainfile = "reflux.min.js"

--- a/files/refluxjs/update.json
+++ b/files/refluxjs/update.json
@@ -1,7 +1,7 @@
 {
 	"packageManager": "github",
 	"name": "refluxjs",
-	"repo": "spoike/refluxjs",
+	"repo": "reflux/refluxjs",
 	"files": {
 		"include": ["dist/reflux.min.js"]
 	}


### PR DESCRIPTION
The refluxjs repo has been moved from a personal github account (https://github.com/spoike/refluxjs) to an organization (https://github.com/reflux/refluxjs).