### PR TITLE
New Project: chassis-components

### DIFF
--- a/files/chassis-components/info.ini
+++ b/files/chassis-components/info.ini
@@ -1,0 +1,5 @@
+author = "Corey Butler"
+github = "https://github.com/ngnjs/chassis-components"
+homepage = "http://ngn.js.org"
+description = "NGN Chassis Components is a library of reusable web components."
+mainfile = "chassis-cycle.min.js"

--- a/files/chassis-components/update.json
+++ b/files/chassis-components/update.json
@@ -1,0 +1,9 @@
+{
+  "packageManager": "github",
+  "name": "chassis-components",
+  "repo": "ngnjs/chassis-components",
+  "files": {
+    "basePath": "dist/",
+    "include": ["*.min.js", "*.html"]
+  }
+}


### PR DESCRIPTION
We've been forced to rename a project due to some naming conflicts. What was `ngn-components` is now `chassis-components`. This PR contains the latest info.ini/update.json files. I will submit another PR to remove the old directory (ngn-components).