### PR TITLE
Adding Quick.JS to JSDelivr

### DIFF
--- a/files/quickjs/info.ini
+++ b/files/quickjs/info.ini
@@ -1,0 +1,6 @@
+author = "Michael Krause"
+github = "https://github.com/MK2018/QuickJS"
+homepage = "http://mk2018.github.io/QuickJS/"
+documentation = "http://quickjs.readthedocs.org/"
+description = "QuickJS is a JS framework aimed at making single page apps simple for everyone."
+mainfile = "quick.min.js"

--- a/files/quickjs/info.ini
+++ b/files/quickjs/info.ini
@@ -1,6 +1,5 @@
 author = "Michael Krause"
 github = "https://github.com/MK2018/QuickJS"
-homepage = "http://mk2018.github.io/QuickJS/"
-documentation = "http://quickjs.readthedocs.org/"
+homepage = "http://quickjs.readthedocs.org/"
 description = "QuickJS is a JS framework aimed at making single page apps simple for everyone."
 mainfile = "quick.min.js"

--- a/files/quickjs/update.json
+++ b/files/quickjs/update.json
@@ -4,6 +4,6 @@
   "repo": "mk2018/QuickJS",
   "files": {
     "basePath": "./build",
-    "include": ["quick.min.js, "quick.min.css"],
+    "include": ["quick.min.js, "quick.min.css"]
   }
 }

--- a/files/quickjs/update.json
+++ b/files/quickjs/update.json
@@ -3,7 +3,7 @@
   "name": "QuickJS",
   "repo": "mk2018/QuickJS",
   "files": {
-    "basePath": "./build",
-    "include": ["quick.min.js", "quick.min.css"]
+    "basePath": "build/",
+    "include": ["quick.min.js", "quick.min.css", "quick.js", "quick.css"]
   }
 }

--- a/files/quickjs/update.json
+++ b/files/quickjs/update.json
@@ -1,0 +1,9 @@
+{
+  "packageManager": "github",
+  "name": "QuickJS",
+  "repo": "mk2018/QuickJS",
+  "files": {
+    "basePath": "./build",
+    "include": ["quick.min.js, "quick.min.css"],
+  }
+}

--- a/files/quickjs/update.json
+++ b/files/quickjs/update.json
@@ -4,6 +4,6 @@
   "repo": "mk2018/QuickJS",
   "files": {
     "basePath": "./build",
-    "include": ["quick.min.js, "quick.min.css"]
+    "include": ["quick.min.js", "quick.min.css"]
   }
 }


### PR DESCRIPTION
This pull request is to add Quick.JS to JSDelivr. Please see http://quickjs.readthedocs.org/en/latest/ for any documentation needed about the project, or see the repo at https://github.com/MK2018/QuickJS. 