### PR TITLE
Add chassis-x

### DIFF
--- a/files/chassis-x/info.ini
+++ b/files/chassis-x/info.ini
@@ -1,0 +1,5 @@
+author = "Corey Butler"
+github = "https://github.com/ngnjs/chassis-libx"
+homepage = "http://ngn.js.org"
+description = "NGNX Chassis provides extended functionality to NGN Chassis."
+mainfile = "chassis.x.min.js"

--- a/files/chassis-x/update.json
+++ b/files/chassis-x/update.json
@@ -1,0 +1,9 @@
+{
+  "packageManager": "github",
+  "name": "chassis-x",
+  "repo": "ngnjs/chassis-libx",
+  "files": {
+    "basePath": "dist/",
+    "include": ["*.min.js"]
+  }
+}


### PR DESCRIPTION
An optional extension library for the existing "chassis" project. This is a related but separately maintained project.