### PR TITLE
Add the Synaptic neural network library

### DIFF
--- a/files/synaptic/info.ini
+++ b/files/synaptic/info.ini
@@ -1,0 +1,5 @@
+author = "Juan Cazala"
+github = "https://github.com/cazala/synaptic"
+homepage = "http://synaptic.juancazala.com/"
+description = "Architecture-free neural network library for node.js and the browser"
+mainfile = "synaptic.min.js"

--- a/files/synaptic/update.json
+++ b/files/synaptic/update.json
@@ -1,0 +1,9 @@
+{
+  "packageManager": "github",
+  "name": "synaptic",
+  "repo": "cazala/synaptic",
+  "files": {
+    "basePath": "dist/",
+    "include": ["synaptic.min.js"]
+  }
+}


### PR DESCRIPTION
This pull request adds [Synaptic](https://github.com/cazala/synaptic), an architecture-free neural network library for node.js and the browser.