### PR TITLE
Changed basepath for next JsBarcode release

### DIFF
--- a/files/jsbarcode/update.json
+++ b/files/jsbarcode/update.json
@@ -3,7 +3,7 @@
   "name": "JsBarcode",
   "repo": "lindell/JsBarcode",
   "files": {
-    "basePath": "bin/browser/",
+    "basePath": "dist/",
     "include": ["*.min.*", "./barcodes/*.min.*"]
   }
 }


### PR DESCRIPTION
The folder of the JsBarcode build has been changed from `bin/browser/` to [`dist/`](https://github.com/lindell/JsBarcode/tree/master/dist). This PR prepares jsdelivr for the next release.