### PR TITLE
Update package.json for jquery.lazy

### DIFF
--- a/files/jquery.lazy/update.json
+++ b/files/jquery.lazy/update.json
@@ -3,6 +3,9 @@
   "name": "jquery.lazy",
   "repo": "eisbehr-/jquery.lazy",
   "files": {
-    "include": ["jquery.lazy.min.js"]
+    "include": [
+      "jquery.lazy.min.js",
+      "jquery.lazy.plugins.min.js"
+    ]
   }
 }


### PR DESCRIPTION
The Library is already available on jsdeliver, I'll just added the new plugin file to cdn too.