### PR TITLE
Updated the path

### DIFF
--- a/files/picnicss/update.json
+++ b/files/picnicss/update.json
@@ -3,7 +3,6 @@
 	"name": "picnicss",
 	"repo": "picnicss/picnic",
 	"files": {
-		"basePath": "releases",
-		"include": ["picnic.min.css", "plugins.min.css"]
+		"include": "picnic.min.css"
 	}
 }

--- a/files/picnicss/update.json
+++ b/files/picnicss/update.json
@@ -3,6 +3,6 @@
 	"name": "picnicss",
 	"repo": "picnicss/picnic",
 	"files": {
-		"include": "picnic.min.css"
+		"include": ["picnic.min.css"]
 	}
 }


### PR DESCRIPTION
Updated the recommended path for Picnic CSS. Now the main file is **not** inside the `/releases`, however there is a copy there for retro-compatibility.