### PR TITLE
Selectize.js: don't include any files from `dist/less`

### DIFF
--- a/files/selectize/update.json
+++ b/files/selectize/update.json
@@ -4,6 +4,6 @@
   "repo": "brianreavis/selectize.js",
   "files": {
     "basePath": "dist/",
-    "exclude": ["less/*"]
+    "exclude": ["less/**/*"]
   }
 }


### PR DESCRIPTION
This should also trigger (I hope so) the bot to update selectize after commit https://github.com/jsdelivr/jsdelivr/commit/542e6e8d2242a2a2bb9ec73280ca3415c2bf3fb8