### PR TITLE
Add AMDCDN

### DIFF
--- a/files/amdcdn/info.ini
+++ b/files/amdcdn/info.ini
@@ -1,0 +1,5 @@
+author = "Zebulon McCorkle"
+github = "https://github.com/zebMcCorkle/amdcdn"
+homepage = "https://github.com/zebMcCorkle/amdcdn"
+description = "An AMD module loader that can load modules from a CDN"
+mainfile = "output.min.js"

--- a/files/amdcdn/update.json
+++ b/files/amdcdn/update.json
@@ -1,5 +1,5 @@
 {
-  "packageManager": "github",
+  "packageManager": "npm",
   "name": "amdcdn",
   "repo": "zebMcCorkle/amdcdn",
   "files": {

--- a/files/amdcdn/update.json
+++ b/files/amdcdn/update.json
@@ -1,0 +1,8 @@
+{
+  "packageManager": "github",
+  "name": "amdcdn",
+  "repo": "zebMcCorkle/amdcdn",
+  "files": {
+    "include": ["output.js", "output.min.js"]
+  }
+}


### PR DESCRIPTION
> An AMD module loader that can load modules from a CDN

Built for jsDelivr, so I figure it should be hosted _on_ jsDelivr.