### PR TITLE
Add map-icons.js

### DIFF
--- a/files/map-icons/info.ini
+++ b/files/map-icons/info.ini
@@ -1,0 +1,5 @@
+author = "Scott de Jonge"
+github = "https://github.com/scottdejonge/map-icons"
+homepage = "http://map-icons.com/"
+description = "An icon font for use with Google Maps API and Google Places API using SVG markers and icon labels"
+mainfile = "map-icons.min.js"

--- a/files/map-icons/update.json
+++ b/files/map-icons/update.json
@@ -1,0 +1,9 @@
+{
+  "packageManager": "github",
+  "name": "map-icons",
+  "repo": "scottdejonge/map-icons",
+  "files": {
+    "basePath": "dist/",
+    "include": ["js/map-icons.min.js", "css/map-icons.min.css", "fonts/map-icons.eot", "fonts/map-icons.svg", "fonts/map-icons.ttf", "fonts/map-icons.woff"]
+  }
+}

--- a/files/map-icons/update.json
+++ b/files/map-icons/update.json
@@ -4,6 +4,6 @@
   "repo": "scottdejonge/map-icons",
   "files": {
     "basePath": "dist/",
-    "include": ["js/map-icons.min.js", "css/map-icons.min.css", "fonts/map-icons.eot", "fonts/map-icons.svg", "fonts/map-icons.ttf", "fonts/map-icons.woff"]
+    "include": ["js/map-icons.min.js", "js/map-icons.js", "css/map-icons.min.css", "css/map-icons.css", "fonts/map-icons.eot", "fonts/map-icons.svg", "fonts/map-icons.ttf", "fonts/map-icons.woff"]
   }
 }


### PR DESCRIPTION
Map Icons is an icon font for use with Google Maps API and Google Places API using SVG markers and icon labels.

Map Icons makes Google Maps Markers dynamic with control over shape, color, size, and icon easily changed using options in the marker object as well as simple SVG Notation and CSS.