### PR TITLE
added apiNG plugin for football-data.org

### DIFF
--- a/files/aping.plugin-footballdata/info.ini
+++ b/files/aping.plugin-footballdata/info.ini
@@ -1,0 +1,5 @@
+author = "Jonathan Hornung"
+github = "https://github.com/JohnnyTheTank/apiNG-plugin-footballdata"
+homepage = "https://github.com/JohnnyTheTank/apiNG-plugin-footballdata"
+description = "apiNG-plugin-footballdata is a football-data.org API plugin for apiNG."
+mainfile = "aping-plugin-footballdata.min.js"

--- a/files/aping.plugin-footballdata/update.json
+++ b/files/aping.plugin-footballdata/update.json
@@ -1,0 +1,8 @@
+{
+  "packageManager": "github",
+  "name": "apiNG-plugin-footballdata",
+  "repo": "JohnnyTheTank/apiNG-plugin-footballdata",
+  "files": {
+    "include": ["dist/*"]
+  }
+}


### PR DESCRIPTION
New [apiNG](https://github.com/JohnnyTheTank/apiNG) plugin for [football-data.org](http://api.football-data.org/documentation)