### PR TITLE
figuration - update homepage url

### DIFF
--- a/files/figuration/info.ini
+++ b/files/figuration/info.ini
@@ -1,5 +1,5 @@
 author = "CAST"
 github = "https://github.com/cast-org/figuration"
-homepage = "https://cast-org.github.io/figuration/"
+homepage = "http://figuration.org"
 description = "A feature rich, responsive, mobile first, accessible, front-end framework based on Bootstrap."
 mainfile = "js/figuration.min.js"


### PR DESCRIPTION
Changing from https://cast-org.github.io/figuration/
to http://figuration.org