### PR TITLE
pull nouislider from bower

### DIFF
--- a/files/jquery.nouislider/update.json
+++ b/files/jquery.nouislider/update.json
@@ -1,6 +1,6 @@
 {
-  "packageManager": "github",
-  "name": "noUiSlider",
+  "packageManager": "bower",
+  "name": "nouislider",
   "repo": "leongersen/noUiSlider",
   "files": {
     "basePath": "distribute/",


### PR DESCRIPTION
The latest of this seems to be 8.5.1 . 

Pull nouislider from bower, as compared to github
