### PR TITLE
Add new basePath for howler.js

### DIFF
--- a/files/howler.js/update.json
+++ b/files/howler.js/update.json
@@ -3,6 +3,7 @@
   "name": "howlerjs",
   "repo": "goldfire/howler.js",
   "files": {
+    "basePath": ["dist/"],
     "include": ["howler.js", "howler.min.js"]
   }
 }


### PR DESCRIPTION
The distribution files in howler.js v2.0.0 have been moved from root to `dist/`. This adds `dist/` to the `basePath` in the updates.json file.