### PR TITLE
Extracted the basePath out of the file names.

### DIFF
--- a/files/rapidoid/update.json
+++ b/files/rapidoid/update.json
@@ -3,6 +3,7 @@
   "name": "rapidoid",
   "repo": "rapidoid/rapidoid",
   "files": {
-    "include": ["rapidoid-html/src/main/resources/default/static/rapidoid.min.js", "rapidoid-html/src/main/resources/default/static/rapidoid.min.css"]
+    "basePath": "rapidoid-html/src/main/resources/default/static/",
+    "include": ["rapidoid.min.js", "rapidoid.min.css"]
   }
 }


### PR DESCRIPTION
I hope this will fix the update of the Rapidoid files, which currently isn't working for the latest releases (5.2.0, 5.2.1, 5.2.2).