### PR TITLE
Create update.json for visionmedia/move.js

### DIFF
--- a/files/move.js/update.json
+++ b/files/move.js/update.json
@@ -1,0 +1,10 @@
+{
+  "packageManager": "github",
+  "name": "move.js",
+  "repo": "visionmedia/move.js",
+  "files": {
+    "include": [
+      "move.js", "move.min.js"
+    ]
+  }
+}


### PR DESCRIPTION
For some reason, there was no update.json for visionmedia/move.js project and http://www.jsdelivr.com/projects/move.js is showing that latest is v0.1.1, but it's v0.5.0 now: https://github.com/visionmedia/move.js/releases