### PR TITLE
build wingcss using npm (not github)

### DIFF
--- a/files/wing/update.json
+++ b/files/wing/update.json
@@ -1,6 +1,6 @@
 {
-	"packageManager": "github",
-	"name": "wing",
+	"packageManager": "npm",
+	"name": "wingcss",
 	"repo": "KingPixil/wing",
 	"files": {
 		"basePath": "dist/",


### PR DESCRIPTION
I update this because the repo is at version 0.1.7; but wingcss on jsdelivr is 0.1.5 (see https://cdn.jsdelivr.net/wing/0.1.7/wing.min.css )

Thank you!