### PR TITLE
Update project crypto-js to last github version

### DIFF
--- a/files/crypto-js/info.ini
+++ b/files/crypto-js/info.ini
@@ -1,4 +1,4 @@
-author = "Jeff.Mott.OR, Evan Vosberg and contributors"
+author = "Jeff.Mott.OR and Evan Vosberg"
 github = "https://github.com/brix/crypto-js"
 homepage = "https://github.com/brix/crypto-js/"
 description = "JavaScript implementations of standard and secure cryptographic algorithms"

--- a/files/crypto-js/info.ini
+++ b/files/crypto-js/info.ini
@@ -1,5 +1,5 @@
-author = "Jeff.Mott.OR"
-github = ""
-homepage = "https://code.google.com/p/crypto-js/"
+author = "Jeff.Mott.OR, Evan Vosberg and contributors"
+github = "https://github.com/brix/crypto-js"
+homepage = "https://github.com/brix/crypto-js/"
 description = "JavaScript implementations of standard and secure cryptographic algorithms"
 mainfile = "rollups/sha256.js"


### PR DESCRIPTION
Update the path of the project as the google project is dead. Now using github fork of @brix which is the most used one.