### PR TITLE
WIP | Fix is.js not being updated

### DIFF
--- a/files/is.js/info.ini
+++ b/files/is.js/info.ini
@@ -1,5 +1,5 @@
 author = "arasatasaygin"
 github = "https://github.com/arasatasaygin/is.js"
-homepage = "http://arasatasaygin.github.io/is.js/"
+homepage = "http://is.js.org"
 description = "Check types, regexps, presence, time and more..."
 mainfile = "is.min.js"

--- a/files/is.js/update.json
+++ b/files/is.js/update.json
@@ -3,6 +3,6 @@
   "name": "is.js",
   "repo": "arasatasaygin/is.js",
   "files": {
-    "include": ["is.min.js"]
+    "include": [ "is.min.js" ]
   }
 }


### PR DESCRIPTION
I don't really see why it is not being updated, but there are lot's of releases after `v0.52`, which is the only version available on the CDN at the moment.

@megawac do you have any idea? Maybe libgrabber is just stuck? Because I can't really see why it isn't pulling the latest changes.

[arasatasaygin/is.js/releases](https://github.com/arasatasaygin/is.js/releases)