### PR TITLE
Added cookieconsent3 from silktide/insites

### DIFF
--- a/files/cookieconsent3/info.ini
+++ b/files/cookieconsent3/info.ini
@@ -1,0 +1,5 @@
+author = "Insites"
+github = "https://github.com/insites/cookieconsent"
+homepage = "https://cookieconsent.insites.com"
+description = "A free solution to the EU Cookie Law"
+mainfile = "cookieconsent.min.js"

--- a/files/cookieconsent3/update.json
+++ b/files/cookieconsent3/update.json
@@ -1,0 +1,8 @@
+{
+  "packageManager": "github",
+  "name": "cookieconsent3",
+  "repo": "insites/cookieconsent",
+  "files": {
+    "basePath": "build/"
+  }
+}


### PR DESCRIPTION
The current latest version of the cookie consent library available on jsDelivr is 1.0.9.
This adds the latest versions, up to 3.0.4 at the current time.