### PR TITLE
Point D3js at the npm distribution

### DIFF
--- a/files/d3js/update.json
+++ b/files/d3js/update.json
@@ -1,8 +1,9 @@
 {
-  "packageManager": "github",
-  "name": "d3js",
-  "repo": "mbostock/d3",
+  "packageManager": "npm",
+  "name": "d3",
+  "repo": "d3/d3",
   "files": {
+    "basePath": "build/",
     "include": ["d3.js", "d3.min.js"]
   }
 }


### PR DESCRIPTION
Fixes https://github.com/jsdelivr/jsdelivr/issues/15568. The D3 repo was moved and broken up into several different repos, so build files no longer exist in the repo, but they are built when publishing to npm. Therefore it's easier to just point JSDelivr at the npm distribution where the build files exist.