### PR TITLE
Add utf8.js

### DIFF
--- a/files/utf8/info.ini
+++ b/files/utf8/info.ini
@@ -1,0 +1,5 @@
+author = "Mathias Bynens"
+github = "https://github.com/mathiasbynens/utf8.js"
+homepage = "https://github.com/mathiasbynens/utf8.js"
+description = "utf8.js is a well-tested UTF-8 encoder/decoder written in JavaScript"
+mainfile = "utf8.js"

--- a/files/utf8/update.json
+++ b/files/utf8/update.json
@@ -1,0 +1,8 @@
+{
+  "packageManager": "github",
+  "name": "utf8.js",
+  "repo": "mathiasbynens/utf8.js",
+  "files": {
+    "include": ["utf8.js"]
+  }
+}


### PR DESCRIPTION
Add [utf8.js](https://github.com/mathiasbynens/utf8.js), a well-tested UTF-8 encoder/decoder written in JavaScript.

I could not find the minimized version of utf8.js anywhere but [cdnjs](https://github.com/cdnjs/cdnjs/tree/51b9d1af8baece59312ab52befaa0c3c7f6cf0f8/ajax/libs/utf8), and so this will only use the uncompressed version.