### PR TITLE
Tsumegumi.js: Maintainer / Owner changed

### DIFF
--- a/files/tsumegumi/info.ini
+++ b/files/tsumegumi/info.ini
@@ -1,5 +1,5 @@
-author = "Alliance Port, LLC"
-github = "https://github.com/allianceport/tsumegumi.js"
-homepage = "http://www.kumihan.org"
+author = "Grenouille 220"
+github = "https://github.com/grenouille220/tsumegumi.js"
+homepage = "https://github.com/grenouille220/tsumegumi.js"
 description = "Simple font kerning via javascript. Derivative and modified work from Takayuki Fukatsu."
 mainfile = "tsumegumi.min.js"

--- a/files/tsumegumi/update.json
+++ b/files/tsumegumi/update.json
@@ -1,7 +1,7 @@
 {
   "packageManager": "github",
   "name": "tsumegumi",
-  "repo": "allianceport/tsumegumi.js",
+  "repo": "grenouille220/tsumegumi.js",
   "files": {
     "include": ["tsumegumi.js","tsumegumi.min.js"],
     "exclude": ["package.json","update.json","README.md"]


### PR DESCRIPTION
Tsumegumi.js repository has been transferred from company's account to my personal account.
Maintenance issue. Please reflect the change for the CDN too. No hurry.

Thank you in advance and sorry for the inconvenience