### PR TITLE
Add corejs-typeahead (maintained fork of Twitter typeahead)

### DIFF
--- a/files/corejs-typeahead/info.ini
+++ b/files/corejs-typeahead/info.ini
@@ -1,0 +1,5 @@
+author = "CoreJs"
+github = "https://github.com/corejavascript/typeahead.js"
+homepage = "https://typeahead.js.org/"
+description = "typeahead.js is a fast and fully-featured autocomplete library"
+mainfile = "typeahead.jquery.min.js"

--- a/files/corejs-typeahead/info.ini
+++ b/files/corejs-typeahead/info.ini
@@ -1,4 +1,4 @@
-author = "CoreJs"
+author = "CoreJS"
 github = "https://github.com/corejavascript/typeahead.js"
 homepage = "https://typeahead.js.org/"
 description = "typeahead.js is a fast and fully-featured autocomplete library"

--- a/files/corejs-typeahead/update.json
+++ b/files/corejs-typeahead/update.json
@@ -1,0 +1,9 @@
+{
+  "packageManager": "github",
+  "name": "typeahead.js",
+  "repo": "corejavascript/typeahead.js",
+  "files": {
+    "basePath": "dist",
+    "include": ["*.js"],
+  }
+}

--- a/files/corejs-typeahead/update.json
+++ b/files/corejs-typeahead/update.json
@@ -1,9 +1,9 @@
 {
-  "packageManager": "github",
-  "name": "typeahead.js",
-  "repo": "corejavascript/typeahead.js",
-  "files": {
-    "basePath": "dist",
-    "include": ["*.js"],
-  }
+	"packageManager": "github",
+	"name": "typeahead.js",
+	"repo": "corejavascript/typeahead.js",
+	"files": {
+		"basePath": "dist",
+		"include": ["*.js"]
+	}
 }


### PR DESCRIPTION
The version of typeahead.js autocomplete library currently hosted ([v0.11.1](https://github.com/twitter/typeahead.js/)) on jsdelivr is no longer maintained. A maintained fork is available ([v1.1.1](https://github.com/corejavascript/typeahead.js)) from the CoreJS organisation on github.
