### PR TITLE
Add Selectr

### DIFF
--- a/files/selectr/info.ini
+++ b/files/selectr/info.ini
@@ -1,0 +1,6 @@
+
+author = "Karl Saunders"
+github = "https://github.com/Mobius1/Selectr"
+homepage = "http://mobius.ovh/docs/selectr"
+description = "A lightweight dependency-free select box replacement written in vanilla javascript. Similar to Select2 and Chosen without the dependencies."
+mainfile = "selectr.min.js"

--- a/files/selectr/update.json
+++ b/files/selectr/update.json
@@ -1,0 +1,9 @@
+
+{
+  "packageManager": "npm",
+  "name": "mobius1-selectr",
+  "files": {
+    "basePath": "dist/",
+    "include": ["selectr.min.js", "selectr.min.css"]
+  }
+}


### PR DESCRIPTION
Add Selectr. A lightweight dependency-free select box replacement written in vanilla javascript. Similar to Select2 and Chosen without the dependencies.