### PR TITLE
mui: Switch to npm

### DIFF
--- a/files/mui/update.json
+++ b/files/mui/update.json
@@ -1,7 +1,6 @@
 {
-	"packageManager": "github",
-	"name": "mui",
-	"repo": "muicss/mui",
+	"packageManager": "npm",
+	"name": "muicss",
 	"files": {
 		"basePath": "dist/"
 	}


### PR DESCRIPTION
The `dist/` directory no longer exists in github source tree.

Switching to npm should fix the update.