### PR TITLE
NPM isn't auto-updating. Moving to GitHub.

### DIFF
--- a/files/p5.js/update.json
+++ b/files/p5.js/update.json
@@ -1,9 +1,11 @@
 {
-  "packageManager": "npm",
+  "packageManager": "github",
   "name": "p5",
   "repo": "processing/p5.js",
   "files": {
-    "basePath": "lib/",
-    "include": ["p5.js", "p5.min.js", "addons/**/*"]
+    "basePath": "releases/download/**/",
+    "include": ["p5.js", "p5.min.js",
+                "p5.dom.js", "p5.dom.min.js",
+                "p5.sound.js", "p5.sound.min.js"]
   }
 }


### PR DESCRIPTION
* Latest 0.58 has failed to auto-update -> https://github.com/processing/p5.js/releases/tag/0.5.8
* Changing it to get from GitHub now.
* Bonus: "p5.dom.min.js" & "p5.sound.min.js" minified versions are available there.
* Expecting JSDelivr can grab files directly from basePath: "releases/download/**/" though.